### PR TITLE
Enhance tender pages with bilingual support and language switcher

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,3 +8,13 @@ title: "Page not found"
   <p>The page you requested could not be found.</p>
   <p><a href="{{ '/' | relative_url }}">Return to Tenders</a></p>
 </div>
+<script>
+(function() {
+  var path = window.location.pathname;
+  var m = path.match(/^\/tenders\/(.+-khmer)\/?$/);
+  if (m) {
+    var slug = m[1].replace(/-khmer$/, '');
+    window.location.replace(path.replace(/\/tenders\/.+-khmer\/?/, '/tenders/' + slug + '/'));
+  }
+})();
+</script>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ Static tender pages built with Jekyll, deployable to GitHub Pages. Procurement s
 
 ## Adding a new tender
 
-1. Create a new Markdown file under `_tenders/`, e.g. `_tenders/my-org-2026-0003.md`.
+1. Copy the template and create a new tender file:
+   ```bash
+   cp _templates/tender.md _tenders/<slug>.md
+   ```
+   Use a `slug` for the URL (e.g. `my-org-2026-0003` → `/tenders/my-org-2026-0003/`). See `_templates/README.md` for details.
 
-2. Use the front matter and structure from the [Data Model](#data-model) below. Copy from an existing tender (e.g. `_tenders/fh-2026-0001.md`) and edit.
+2. Edit `_tenders/<slug>.md`: fill in the placeholders and remove any sections you don't need. Use the [Data Model](#data-model) below for field descriptions.
 
 3. Set `published: true` when the tender is ready to appear on the homepage. Set `published: false` to hide it (the detail page remains buildable if someone has the URL).
 
@@ -34,6 +38,48 @@ Static tender pages built with Jekyll, deployable to GitHub Pages. Procurement s
 
 - **Publish:** Set `published: true` in the tender’s front matter. It will show on the homepage and in search.
 - **Unpublish:** Set `published: false`. It will not appear on the homepage or in search. The tender detail page still exists at `/tenders/<slug>/` if the file remains in `_tenders/`. To remove it entirely, delete the file or move it out of `_tenders/`.
+
+## Language switcher (English / Khmer)
+
+Use **one tender file per tender**. The tender layout is bilingual: each detail page shows an **English | ភាសាខ្មែរ** switcher at the top. Section labels (Deadline, Summary, Scope of Work, etc.) and all content can toggle between English and Khmer. The chosen language is stored in `localStorage` so it persists across visits. The list page shows each tender once; users open the tender and switch language on the detail page if needed.
+
+### Bilingual content (optional Khmer)
+
+To show **translated content** when the user selects Khmer (not just translated labels), add optional Khmer fields in the same tender file. If a Khmer value is missing, the English value is shown as fallback.
+
+| English field | Khmer option | Notes |
+|---------------|--------------|--------|
+| `title` | `title_km` | |
+| `summary` | `summary_km` | |
+| `buyer.name` | `buyer_km.name` | |
+| `deadline.note` | `deadline_km.note` | |
+| `scope` | Each item: string or `{ en: "...", km: "..." }` | Same for `eligibility_requirements`, `required_documents` |
+| `submission.rules` | Each item: string or `{ en: "...", km: "..." }` | |
+| `submission.instructions` | `submission_km.instructions` | |
+| `submission.subject_line_format` | `submission_km.subject_line_format` | |
+| `submission.physical_address` | `submission_km.physical_address` | |
+| `submission.addresses` | Each item: string or `{ en: "...", km: "..." }` | |
+| `submission.clarification_deadline` | `submission_km.clarification_deadline` | |
+| `commercial_terms.warranty` | `commercial_terms_km.warranty` | |
+| `commercial_terms.payment_terms` | `commercial_terms_km.payment_terms` | |
+| `evaluation.criteria` | Each item: string or `{ en: "...", km: "..." }` | |
+| `evaluation.scoring[].label` | `label_km` on each scoring item | |
+| `required_submissions[].label` | `label_km` on each item | Same for `note_km` |
+| `resources[].label` | `label_km` on each item | Same for `note_km` |
+| `attachments[].label` | `label_km` on each item | |
+| `contacts[].name` | `name_km` on each contact | Same for `role_km`, `location_label_km` |
+| `goods[].description` | `description_km` on each item | Same for `specification_km` |
+| `key_dates[].label` | `label_km` on each item | Same for `note_km` |
+| Body (main content) | `body_km` | Markdown string in front matter; rendered when Khmer is selected |
+
+Example (scope with bilingual items):
+
+```yaml
+scope:
+  - en: "Component A: Review CGCC's existing bond guarantee framework..."
+    km: "ផ្នែក ក៖ ពិនិត្យរូបមន្តធានាមូលបត្រ..."
+  - "Single string shows in both languages."
+```
 
 ## Vendor form link
 
@@ -68,7 +114,7 @@ Each tender is a Markdown file in `_tenders/` with at least:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `layout` | Yes | Set to `tender`. |
+| `layout` | Yes | Set to `tender`. The page includes an EN/Khmer language switcher. |
 | `title` | Yes | Tender title. |
 | `tender_id` | Yes | Unique id (e.g. `FH-2026-0001`). Used for the vendor form query param. |
 | `published` | Yes | `true` to show on homepage, `false` to hide. |

--- a/_config.yml
+++ b/_config.yml
@@ -33,3 +33,4 @@ exclude:
   - .git
   - .github
   - vendor
+  - _templates

--- a/_layouts/tender.html
+++ b/_layouts/tender.html
@@ -2,10 +2,17 @@
 layout: default
 ---
 
-<article class="tender-detail">
+<article class="tender-detail" data-tender-lang="en" id="tender-detail">
   <div class="wrap">
     <header class="tender-header">
-      <h1 class="tender-title">{{ page.title }}</h1>
+      <div class="tender-lang-switcher-wrap">
+        <span class="tender-lang-switcher" role="group" aria-label="Switch language">
+          <button type="button" class="tender-lang-btn active" data-lang="en" aria-pressed="true">English</button>
+          <span class="tender-lang-sep" aria-hidden="true">|</span>
+          <button type="button" class="tender-lang-btn" data-lang="km" aria-pressed="false">ភាសាខ្មែរ</button>
+        </span>
+      </div>
+      <h1 class="tender-title"><span class="tender-lang-en">{{ page.title }}</span><span class="tender-lang-km">{{ page.title_km | default: page.title }}</span></h1>
       {% if page.tender_ref or page.issue_date %}
       <p class="tender-meta">
         {% if page.tender_ref %}<span class="tender-ref">{{ page.tender_ref }}</span>{% endif %}
@@ -14,7 +21,7 @@ layout: default
       </p>
       {% endif %}
       {% if page.buyer.name %}
-      <p class="tender-buyer">{{ page.buyer.name }}</p>
+      <p class="tender-buyer"><span class="tender-lang-en">{{ page.buyer.name }}</span><span class="tender-lang-km">{{ page.buyer_km.name | default: page.buyer.name }}</span></p>
       {% endif %}
       {% if page.location.province or page.location.district or page.location.address_text %}
       <p class="tender-location">
@@ -25,23 +32,23 @@ layout: default
       {% endif %}
       {% if page.deadline.datetime %}
       <p class="tender-deadline">
-        <strong>Deadline:</strong>
+        <strong><span class="tender-lang-en">Deadline:</span><span class="tender-lang-km">ថ្ងៃផុតកំណត់៖</span></strong>
         <time datetime="{{ page.deadline.datetime }}">{{ page.deadline.datetime | date: "%B %d, %Y at %I:%M %p" }}</time>
         {% if page.deadline.timezone_label %} ({{ page.deadline.timezone_label }}){% endif %}
-        {% if page.deadline.note %} &ndash; {{ page.deadline.note }}{% endif %}
+        {% if page.deadline.note %} &ndash; <span class="tender-lang-en">{{ page.deadline.note }}</span><span class="tender-lang-km">{{ page.deadline_km.note | default: page.deadline.note }}</span>{% endif %}
       </p>
       {% endif %}
 
       {% if page.key_dates and page.key_dates.size > 0 %}
       <div class="tender-key-dates">
-        <strong>Key dates</strong>
+        <strong><span class="tender-lang-en">Key dates</span><span class="tender-lang-km">កាលបរិច្ឆេទសំខាន់</span></strong>
         <ul class="key-dates-list">
           {% for kd in page.key_dates %}
           <li>
-            <span class="key-date-label">{{ kd.label }}:</span>
+            <span class="key-date-label"><span class="tender-lang-en">{{ kd.label }}:</span><span class="tender-lang-km">{{ kd.label_km | default: kd.label }}:</span></span>
             <time datetime="{{ kd.datetime }}">{{ kd.datetime | date: "%B %d, %Y" }}</time>
             {% if kd.timezone_label %} ({{ kd.timezone_label }}){% endif %}
-            {% if kd.note %} &ndash; {{ kd.note }}{% endif %}
+            {% if kd.note %} &ndash; <span class="tender-lang-en">{{ kd.note }}</span><span class="tender-lang-km">{{ kd.note_km | default: kd.note }}</span>{% endif %}
           </li>
           {% endfor %}
         </ul>
@@ -56,26 +63,26 @@ layout: default
           {% assign cta_url = form_base | append: "?tender_id=" | append: page.tender_id %}
         {% endif %}
       <p class="tender-cta">
-        <a class="btn btn-primary" href="{{ cta_url }}" target="_blank" rel="noopener noreferrer">Submit Interest / Ask a Question</a>
+        <a class="btn btn-primary" href="{{ cta_url }}" target="_blank" rel="noopener noreferrer"><span class="tender-lang-en">Submit Interest / Ask a Question</span><span class="tender-lang-km">ដាក់ជាមតិ / សួរសំណួរ</span></a>
       </p>
       {% else %}
-      <p class="tender-cta-note">Vendor response form not available.</p>
+      <p class="tender-cta-note"><span class="tender-lang-en">Vendor response form not available.</span><span class="tender-lang-km">ទម្រង់ឆ្លើយតបរបស់អ្នកផ្គត់ផ្គង់មិនមាន។</span></p>
       {% endif %}
     </header>
 
     {% if page.summary %}
     <section class="tender-section">
-      <h2>Summary</h2>
-      <p>{{ page.summary }}</p>
+      <h2><span class="tender-lang-en">Summary</span><span class="tender-lang-km">សង្ខេប</span></h2>
+      <p><span class="tender-lang-en">{{ page.summary }}</span><span class="tender-lang-km">{{ page.summary_km | default: page.summary }}</span></p>
     </section>
     {% endif %}
 
     {% if page.scope and page.scope.size > 0 %}
     <section class="tender-section">
-      <h2>Scope of Work</h2>
+      <h2><span class="tender-lang-en">Scope of Work</span><span class="tender-lang-km">វិសាលភាពការងារ</span></h2>
       <ul>
         {% for item in page.scope %}
-        <li>{{ item }}</li>
+        <li><span class="tender-lang-en">{% if item.en %}{{ item.en }}{% else %}{{ item }}{% endif %}</span><span class="tender-lang-km">{% if item.km %}{{ item.km }}{% elsif item.en %}{{ item.en }}{% else %}{{ item }}{% endif %}</span></li>
         {% endfor %}
       </ul>
     </section>
@@ -83,10 +90,10 @@ layout: default
 
     {% if page.eligibility_requirements and page.eligibility_requirements.size > 0 %}
     <section class="tender-section">
-      <h2>Eligibility</h2>
+      <h2><span class="tender-lang-en">Eligibility</span><span class="tender-lang-km">លក្ខខណ្ឌគ្រប់គ្រាន់</span></h2>
       <ul>
         {% for item in page.eligibility_requirements %}
-        <li>{{ item }}</li>
+        <li><span class="tender-lang-en">{% if item.en %}{{ item.en }}{% else %}{{ item }}{% endif %}</span><span class="tender-lang-km">{% if item.km %}{{ item.km }}{% elsif item.en %}{{ item.en }}{% else %}{{ item }}{% endif %}</span></li>
         {% endfor %}
       </ul>
     </section>
@@ -94,10 +101,10 @@ layout: default
 
     {% if page.required_documents and page.required_documents.size > 0 %}
     <section class="tender-section">
-      <h2>Required Documents</h2>
+      <h2><span class="tender-lang-en">Required Documents</span><span class="tender-lang-km">ឯកសារត្រូវការ</span></h2>
       <ul>
         {% for doc in page.required_documents %}
-        <li>{{ doc }}</li>
+        <li><span class="tender-lang-en">{% if doc.en %}{{ doc.en }}{% else %}{{ doc }}{% endif %}</span><span class="tender-lang-km">{% if doc.km %}{{ doc.km }}{% elsif doc.en %}{{ doc.en }}{% else %}{{ doc }}{% endif %}</span></li>
         {% endfor %}
       </ul>
     </section>
@@ -105,32 +112,29 @@ layout: default
 
     {% if page.goods and page.goods.size > 0 %}
     <section class="tender-section tender-goods-section">
-      <h2>Goods / Items</h2>
+      <h2><span class="tender-lang-en">Goods / Items</span><span class="tender-lang-km">ផលិតផល / របស់</span></h2>
       <div class="tender-goods-table-wrap">
         <table class="tender-goods-table">
           <thead>
             <tr>
-              <th scope="col">№</th>
-              <th scope="col">Description</th>
-              <th scope="col">Specification</th>
-              <th scope="col">Unit</th>
-              <th scope="col">Qty</th>
+              <th scope="col"><span class="tender-lang-en">№</span><span class="tender-lang-km">ល.រ</span></th>
+              <th scope="col"><span class="tender-lang-en">Description</span><span class="tender-lang-km">ការពិពណ៌នា</span></th>
+              <th scope="col"><span class="tender-lang-en">Specification</span><span class="tender-lang-km">លក្ខណៈបច្ចេកទេស</span></th>
+              <th scope="col"><span class="tender-lang-en">Unit</span><span class="tender-lang-km">ឯកតា</span></th>
+              <th scope="col"><span class="tender-lang-en">Qty</span><span class="tender-lang-km">បរិមាណ</span></th>
             </tr>
           </thead>
           <tbody>
             {% for item in page.goods %}
             <tr>
               <td class="tender-goods-num">{{ forloop.index }}</td>
-              <td class="tender-goods-desc">{{ item.description }}</td>
+              <td class="tender-goods-desc"><span class="tender-lang-en">{{ item.description }}</span><span class="tender-lang-km">{{ item.description_km | default: item.description }}</span></td>
               <td class="tender-goods-spec">
-                {% if item.specification %}
-                  {% if item.specification.size %}
-                    {% for line in item.specification %}
-                      {{ line }}{% unless forloop.last %}<br>{% endunless %}
-                    {% endfor %}
-                  {% else %}
-                    {{ item.specification | newline_to_br }}
-                  {% endif %}
+                {% assign spec_en = item.specification %}
+                {% assign spec_km = item.specification_km | default: item.specification %}
+                {% if spec_en %}
+                  <span class="tender-lang-en">{% if spec_en.size %}{% for line in spec_en %}{{ line }}{% unless forloop.last %}<br>{% endunless %}{% endfor %}{% else %}{{ spec_en | newline_to_br }}{% endif %}</span>
+                  <span class="tender-lang-km">{% if spec_km.size %}{% for line in spec_km %}{{ line }}{% unless forloop.last %}<br>{% endunless %}{% endfor %}{% else %}{{ spec_km | newline_to_br }}{% endif %}</span>
                 {% endif %}
               </td>
               <td class="tender-goods-unit">{{ item.unit }}</td>
@@ -145,19 +149,19 @@ layout: default
 
     {% if page.contacts and page.contacts.size > 0 %}
     <section class="tender-section">
-      <h2>Contacts</h2>
+      <h2><span class="tender-lang-en">Contacts</span><span class="tender-lang-km">ទំនាក់ទំនង</span></h2>
       <ul class="contacts-list">
         {% for c in page.contacts %}
         <li class="contact-card">
-          {% if c.name %}<strong>{{ c.name }}</strong>{% endif %}
-          {% if c.role %}<span class="contact-role">{{ c.role }}</span>{% endif %}
+          {% if c.name %}<strong><span class="tender-lang-en">{{ c.name }}</span><span class="tender-lang-km">{{ c.name_km | default: c.name }}</span></strong>{% endif %}
+          {% if c.role %}<span class="contact-role"><span class="tender-lang-en">{{ c.role }}</span><span class="tender-lang-km">{{ c.role_km | default: c.role }}</span></span>{% endif %}
           {% if c.phone and c.phone.size > 0 %}
           <span class="contact-phone">{% for p in c.phone %}<a href="tel:{{ p | replace: ' ', '' }}">{{ p }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
           {% endif %}
           {% if c.email and c.email.size > 0 %}
           <span class="contact-email">{% for e in c.email %}<a href="mailto:{{ e }}">{{ e }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}</span>
           {% endif %}
-          {% if c.location_label %}<span class="contact-location">{{ c.location_label }}</span>{% endif %}
+          {% if c.location_label %}<span class="contact-location"><span class="tender-lang-en">{{ c.location_label }}</span><span class="tender-lang-km">{{ c.location_label_km | default: c.location_label }}</span></span>{% endif %}
           {% if c.address %}<span class="contact-address">{{ c.address }}</span>{% endif %}
         </li>
         {% endfor %}
@@ -166,42 +170,42 @@ layout: default
     {% endif %}
 
     <section class="tender-section">
-      <h2>Submission Instructions</h2>
+      <h2><span class="tender-lang-en">Submission Instructions</span><span class="tender-lang-km">ការណែនាំដាក់ជាមតិ</span></h2>
       {% if page.submission.rules and page.submission.rules.size > 0 %}
-      <p><strong>Submission rules</strong></p>
+      <p><strong><span class="tender-lang-en">Submission rules</span><span class="tender-lang-km">ច្បាប់ចម្លង</span></strong></p>
       <ul class="submission-rules">
         {% for r in page.submission.rules %}
-        <li>{{ r }}</li>
+        <li><span class="tender-lang-en">{% if r.en %}{{ r.en }}{% else %}{{ r }}{% endif %}</span><span class="tender-lang-km">{% if r.km %}{{ r.km }}{% elsif r.en %}{{ r.en }}{% else %}{{ r }}{% endif %}</span></li>
         {% endfor %}
       </ul>
       {% endif %}
       {% if page.submission.instructions %}
-      <p>{{ page.submission.instructions }}</p>
+      <p><span class="tender-lang-en">{{ page.submission.instructions }}</span><span class="tender-lang-km">{{ page.submission_km.instructions | default: page.submission.instructions }}</span></p>
       {% endif %}
       {% if page.submission.methods %}
-      <p><strong>Methods:</strong> {{ page.submission.methods | join: ", " }}</p>
+      <p><strong><span class="tender-lang-en">Methods:</span><span class="tender-lang-km">វិធី៖</span></strong> {{ page.submission.methods | join: ", " }}</p>
       {% endif %}
       {% if page.submission.subject_line_format %}
-      <p><strong>Subject line:</strong> <code class="subject-line-format">{{ page.submission.subject_line_format }}</code></p>
+      <p><strong><span class="tender-lang-en">Subject line:</span><span class="tender-lang-km">ប្រធានបទ៖</span></strong> <code class="subject-line-format"><span class="tender-lang-en">{{ page.submission.subject_line_format }}</span><span class="tender-lang-km">{{ page.submission_km.subject_line_format | default: page.submission.subject_line_format }}</span></code></p>
       {% endif %}
       {% if page.submission.email %}
-      <p><strong>Email:</strong> <a href="mailto:{{ page.submission.email }}">{{ page.submission.email }}</a></p>
+      <p><strong><span class="tender-lang-en">Email:</span><span class="tender-lang-km">អ៉ីមែល៖</span></strong> <a href="mailto:{{ page.submission.email }}">{{ page.submission.email }}</a></p>
       {% endif %}
       {% if page.submission.addresses and page.submission.addresses.size > 0 %}
-      <p><strong>Submission address(es):</strong></p>
+      <p><strong><span class="tender-lang-en">Submission address(es):</span><span class="tender-lang-km">អាសយដ្ឋានដាក់ជាមតិ៖</span></strong></p>
       <ul>
         {% for addr in page.submission.addresses %}
-        <li>{{ addr }}</li>
+        <li><span class="tender-lang-en">{% if addr.en %}{{ addr.en }}{% else %}{{ addr }}{% endif %}</span><span class="tender-lang-km">{% if addr.km %}{{ addr.km }}{% elsif addr.en %}{{ addr.en }}{% else %}{{ addr }}{% endif %}</span></li>
         {% endfor %}
       </ul>
       {% elsif page.submission.physical_address %}
-      <p><strong>Physical address:</strong> {{ page.submission.physical_address }}</p>
+      <p><strong><span class="tender-lang-en">Physical address:</span><span class="tender-lang-km">អាសយដ្ឋានរូបវន្ត៖</span></strong> <span class="tender-lang-en">{{ page.submission.physical_address }}</span><span class="tender-lang-km">{{ page.submission_km.physical_address | default: page.submission.physical_address }}</span></p>
       {% endif %}
       {% if page.submission.clarification_deadline or page.submission.clarification_emails %}
       <p class="submission-clarification">
-        {% if page.submission.clarification_deadline %}<strong>Clarification deadline:</strong> {{ page.submission.clarification_deadline }}. {% endif %}
+        {% if page.submission.clarification_deadline %}<strong><span class="tender-lang-en">Clarification deadline:</span><span class="tender-lang-km">ថ្ងៃផុតកំណត់សុំពន្យល់៖</span></strong> <span class="tender-lang-en">{{ page.submission.clarification_deadline }}</span><span class="tender-lang-km">{{ page.submission_km.clarification_deadline | default: page.submission.clarification_deadline }}</span>. {% endif %}
         {% if page.submission.clarification_emails and page.submission.clarification_emails.size > 0 %}
-        <strong>Clarification emails:</strong> {% for e in page.submission.clarification_emails %}<a href="mailto:{{ e }}">{{ e }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
+        <strong><span class="tender-lang-en">Clarification emails:</span><span class="tender-lang-km">អ៉ីមែលសុំពន្យល់៖</span></strong> {% for e in page.submission.clarification_emails %}<a href="mailto:{{ e }}">{{ e }}</a>{% unless forloop.last %}, {% endunless %}{% endfor %}
         {% endif %}
       </p>
       {% endif %}
@@ -209,12 +213,12 @@ layout: default
 
     {% if page.commercial_terms and page.commercial_terms.bid_validity_days or page.commercial_terms.warranty or page.commercial_terms.payment_terms or page.commercial_terms.currency %}
     <section class="tender-section">
-      <h2>Commercial terms</h2>
+      <h2><span class="tender-lang-en">Commercial terms</span><span class="tender-lang-km">លក្ខខណ្ឌពាណិជ្ជកម្ម</span></h2>
       <ul class="commercial-terms-list">
-        {% if page.commercial_terms.bid_validity_days %}<li><strong>Bid validity:</strong> {{ page.commercial_terms.bid_validity_days }} days minimum after deadline</li>{% endif %}
-        {% if page.commercial_terms.warranty %}<li><strong>Warranty:</strong> {{ page.commercial_terms.warranty }}</li>{% endif %}
-        {% if page.commercial_terms.payment_terms %}<li><strong>Payment:</strong> {{ page.commercial_terms.payment_terms }}</li>{% endif %}
-        {% if page.commercial_terms.currency %}<li><strong>Currency:</strong> {{ page.commercial_terms.currency }}</li>{% endif %}
+        {% if page.commercial_terms.bid_validity_days %}<li><strong><span class="tender-lang-en">Bid validity:</span><span class="tender-lang-km">សុពលភាពជាមតិ៖</span></strong> <span class="tender-lang-en">{{ page.commercial_terms.bid_validity_days }} days minimum after deadline</span><span class="tender-lang-km">{{ page.commercial_terms.bid_validity_days }} ថ្ងៃយ៉ាងតិចបន្ទាប់ពីថ្ងៃផុតកំណត់</span></li>{% endif %}
+        {% if page.commercial_terms.warranty %}<li><strong><span class="tender-lang-en">Warranty:</span><span class="tender-lang-km">ការធានា៖</span></strong> <span class="tender-lang-en">{{ page.commercial_terms.warranty }}</span><span class="tender-lang-km">{{ page.commercial_terms_km.warranty | default: page.commercial_terms.warranty }}</span></li>{% endif %}
+        {% if page.commercial_terms.payment_terms %}<li><strong><span class="tender-lang-en">Payment:</span><span class="tender-lang-km">ការទូទាត់៖</span></strong> <span class="tender-lang-en">{{ page.commercial_terms.payment_terms }}</span><span class="tender-lang-km">{{ page.commercial_terms_km.payment_terms | default: page.commercial_terms.payment_terms }}</span></li>{% endif %}
+        {% if page.commercial_terms.currency %}<li><strong><span class="tender-lang-en">Currency:</span><span class="tender-lang-km">រូបិយប័ណ្ណ៖</span></strong> {{ page.commercial_terms.currency }}</li>{% endif %}
       </ul>
     </section>
     {% endif %}
@@ -223,24 +227,24 @@ layout: default
     {% assign eval_scoring = page.evaluation.scoring | default: "" %}
     {% if page.evaluation and eval_criteria.size > 0 or eval_scoring.size > 0 %}
     <section class="tender-section">
-      <h2>Evaluation</h2>
+      <h2><span class="tender-lang-en">Evaluation</span><span class="tender-lang-km">ការវាយតម្លៃ</span></h2>
       {% if page.evaluation.criteria and page.evaluation.criteria.size > 0 %}
-      <p><strong>Criteria</strong></p>
+      <p><strong><span class="tender-lang-en">Criteria</span><span class="tender-lang-km">ប្រការវាយតម្លៃ</span></strong></p>
       <ul>
         {% for c in page.evaluation.criteria %}
-        <li>{{ c }}</li>
+        <li><span class="tender-lang-en">{% if c.en %}{{ c.en }}{% else %}{{ c }}{% endif %}</span><span class="tender-lang-km">{% if c.km %}{{ c.km }}{% elsif c.en %}{{ c.en }}{% else %}{{ c }}{% endif %}</span></li>
         {% endfor %}
       </ul>
       {% endif %}
       {% if page.evaluation.scoring and page.evaluation.scoring.size > 0 %}
-      <p><strong>Scoring</strong></p>
+      <p><strong><span class="tender-lang-en">Scoring</span><span class="tender-lang-km">ពិន្ទុ</span></strong></p>
       <table class="evaluation-scoring-table">
         <thead>
-          <tr><th scope="col">Criterion</th><th scope="col">Weight</th></tr>
+          <tr><th scope="col"><span class="tender-lang-en">Criterion</span><span class="tender-lang-km">ប្រការ</span></th><th scope="col"><span class="tender-lang-en">Weight</span><span class="tender-lang-km">ទម្ងន់</span></th></tr>
         </thead>
         <tbody>
           {% for s in page.evaluation.scoring %}
-          <tr><td>{{ s.label }}</td><td>{{ s.weight }}</td></tr>
+          <tr><td><span class="tender-lang-en">{{ s.label }}</span><span class="tender-lang-km">{{ s.label_km | default: s.label }}</span></td><td>{{ s.weight }}</td></tr>
           {% endfor %}
         </tbody>
       </table>
@@ -250,15 +254,15 @@ layout: default
 
     {% if page.required_submissions and page.required_submissions.size > 0 %}
     <section class="tender-section">
-      <h2>Required submissions</h2>
-      <p class="section-note">Forms, templates, and documents that must be completed or submitted.</p>
+      <h2><span class="tender-lang-en">Required submissions</span><span class="tender-lang-km">ការដាក់ជាមតិត្រូវការ</span></h2>
+      <p class="section-note"><span class="tender-lang-en">Forms, templates, and documents that must be completed or submitted.</span><span class="tender-lang-km">ទម្រង់ គំរូ និងឯកសារដែលត្រូវបំពេញ ឬដាក់ជាមតិ។</span></p>
       <ul class="required-submissions-list">
         {% for rs in page.required_submissions %}
         <li>
-          {% if rs.url %}<a href="{{ rs.url }}" target="_blank" rel="noopener noreferrer">{{ rs.label }}</a>{% else %}<span>{{ rs.label }}</span>{% endif %}
+          {% if rs.url %}<a href="{{ rs.url }}" target="_blank" rel="noopener noreferrer"><span class="tender-lang-en">{{ rs.label }}</span><span class="tender-lang-km">{{ rs.label_km | default: rs.label }}</span></a>{% else %}<span><span class="tender-lang-en">{{ rs.label }}</span><span class="tender-lang-km">{{ rs.label_km | default: rs.label }}</span></span>{% endif %}
           {% if rs.type %}<span class="req-type">({{ rs.type }})</span>{% endif %}
-          {% if rs.required == false %}<span class="req-optional">optional</span>{% endif %}
-          {% if rs.note %} &ndash; {{ rs.note }}{% endif %}
+          {% if rs.required == false %}<span class="req-optional"><span class="tender-lang-en">optional</span><span class="tender-lang-km">ជម្រើស</span></span>{% endif %}
+          {% if rs.note %} &ndash; <span class="tender-lang-en">{{ rs.note }}</span><span class="tender-lang-km">{{ rs.note_km | default: rs.note }}</span>{% endif %}
         </li>
         {% endfor %}
       </ul>
@@ -267,12 +271,12 @@ layout: default
 
     {% if page.resources and page.resources.size > 0 %}
     <section class="tender-section">
-      <h2>Resources</h2>
+      <h2><span class="tender-lang-en">Resources</span><span class="tender-lang-km">ធនធាន</span></h2>
       <ul class="resources-list">
         {% for r in page.resources %}
         <li>
-          <a href="{{ r.url }}" target="_blank" rel="noopener noreferrer">{{ r.label }}</a>
-          {% if r.note %} &ndash; {{ r.note }}{% endif %}
+          <a href="{{ r.url }}" target="_blank" rel="noopener noreferrer"><span class="tender-lang-en">{{ r.label }}</span><span class="tender-lang-km">{{ r.label_km | default: r.label }}</span></a>
+          {% if r.note %} &ndash; <span class="tender-lang-en">{{ r.note }}</span><span class="tender-lang-km">{{ r.note_km | default: r.note }}</span>{% endif %}
         </li>
         {% endfor %}
       </ul>
@@ -281,29 +285,31 @@ layout: default
 
     {% if page.attachments and page.attachments.size > 0 %}
     <section class="tender-section">
-      <h2>Attachments</h2>
+      <h2><span class="tender-lang-en">Attachments</span><span class="tender-lang-km">ឯកសារភ្ជាប់</span></h2>
       <ul class="attachments-list">
         {% for att in page.attachments %}
         <li>
-          <a href="{{ att.url }}" target="_blank" rel="noopener noreferrer">{{ att.label | default: "Attachment" }}</a>
+          <a href="{{ att.url }}" target="_blank" rel="noopener noreferrer"><span class="tender-lang-en">{{ att.label | default: "Attachment" }}</span><span class="tender-lang-km">{{ att.label_km | default: att.label | default: "ឯកសារភ្ជាប់" }}</span></a>
         </li>
         {% endfor %}
       </ul>
     </section>
     {% endif %}
 
-    {% if content != "" %}
+    {% if content != "" or page.body_km %}
     <section class="tender-section tender-body">
       <div class="prose">
-        {{ content }}
+        <div class="tender-lang-en">{% if content != "" %}{{ content }}{% elsif page.body_km %}{{ page.body_km | markdownify }}{% endif %}</div>
+        <div class="tender-lang-km">{% if page.body_km %}{{ page.body_km | markdownify }}{% else %}{{ content }}{% endif %}</div>
       </div>
     </section>
     {% endif %}
 
     {% if form_base != "" %}
     <p class="tender-cta tender-cta-bottom">
-      <a class="btn btn-primary" href="{{ cta_url }}" target="_blank" rel="noopener noreferrer">Submit Interest / Ask a Question</a>
+      <a class="btn btn-primary" href="{{ cta_url }}" target="_blank" rel="noopener noreferrer"><span class="tender-lang-en">Submit Interest / Ask a Question</span><span class="tender-lang-km">ដាក់ជាមតិ / សួរសំណួរ</span></a>
     </p>
     {% endif %}
   </div>
 </article>
+<script src="{{ '/assets/js/tender-lang.js' | relative_url }}" defer></script>

--- a/_templates/README.md
+++ b/_templates/README.md
@@ -1,0 +1,34 @@
+# Tender template
+
+Use this to create a new tender page.
+
+## Steps
+
+1. **Copy the template**
+   ```bash
+   cp _templates/tender.md _tenders/<slug>.md
+   ```
+   Choose a `slug` that will become the URL: `/tenders/<slug>/`.  
+   Example: `cp _templates/tender.md _tenders/wfp-2026-0003.md` → URL `/tenders/wfp-2026-0003/`.
+
+2. **Fill in the placeholders** in `_tenders/<slug>.md`:
+   - `title`, `tender_id`, `tender_ref`, `date_posted`, `issue_date`
+   - `buyer.name`, `buyer.address`, `buyer.email`
+   - `deadline.datetime`, `deadline.note`
+   - `submission` (methods, rules, email, instructions, subject_line_format)
+   - `summary`, `scope`, `eligibility_requirements`, `required_documents`
+   - `vendor_form.base_url` (Google Form or Tally link)
+   - `contacts`, `attachments`, `required_submissions` as needed
+
+3. **Optional: bilingual (Khmer)**  
+   Add `_km` fields or `en`/`km` objects so the language switcher shows Khmer content. See README “Bilingual content (optional Khmer)” for the full list.
+
+4. **Assets**  
+   Put PDFs, forms, etc. under `assets/tenders/<slug>/` and point `url` in attachments/required_submissions to those paths.
+
+5. **Publish**  
+   Set `published: true` when the tender should appear on the homepage. Use `published: false` to hide it while drafting.
+
+## Data model
+
+See the main [README Data model](../README.md#data-model-front-matter) for required vs optional fields and descriptions.

--- a/_templates/tender.md
+++ b/_templates/tender.md
@@ -1,0 +1,140 @@
+---
+# Tender template – copy to _tenders/<slug>.md (e.g. _tenders/my-org-2026-0003.md)
+# Slug = filename without .md → URL /tenders/<slug>/
+# Remove any section you don't need. Add _km / en+km for bilingual content.
+
+layout: tender
+title: "Tender title in English"
+# title_km: "ការចំណងជើងជាភាសាខ្មែរ"   # optional
+tender_id: "ORG-2026-0001"
+published: false
+date_posted: 2026-01-01
+tender_ref: "RFP/ITB/CFA number"
+issue_date: 2026-01-01
+
+buyer:
+  name: "Full organization name"
+  # name_km: "..."  # optional; or use buyer_km.name below
+  address: "Street, City, Country"
+  phone: []
+  email: ["procurement@example.org"]
+  website: "https://example.org"
+
+# buyer_km:           # optional Khmer
+#   name: "..."
+
+location:
+  province: "Phnom Penh"
+  district: ""
+  commune: ""
+  village: ""
+  address_text: ""
+
+deadline:
+  datetime: "2026-02-01T17:00:00+07:00"
+  timezone_label: "Phnom Penh (UTC+7)"
+  note: "e.g. Late submissions not accepted."
+
+# deadline_km:
+#   note: "..."
+
+# key_dates:          # optional
+#   - label: "Clarification deadline"
+#     datetime: "2026-01-15"
+#     timezone_label: "Phnom Penh (UTC+7)"
+#   - label: "Bid opening"
+#     datetime: "2026-02-02"
+
+vendor_form:
+  base_url: "https://forms.gle/XXXX"
+
+submission:
+  methods: ["email"]
+  rules:
+    - "Rule 1."
+    - "Rule 2."
+  # For bilingual, use:  - en: "..." / km: "..."
+  email: "procurement@example.org"
+  physical_address: ""
+  subject_line_format: "Tender title – Ref number"
+  instructions: "Submit by [time], [date]. Email subject: [subject]. Enquiries: [subject] - Enquiry."
+
+# submission_km:      # optional
+#   instructions: "..."
+#   subject_line_format: "..."
+
+contacts:
+  - name: "Contact name"
+    # name_km: "..."
+    role: "Procurement"
+    # role_km: "..."
+    email: ["procurement@example.org"]
+    location_label: "Program / Office"
+    # location_label_km: "..."
+
+summary: "One or two sentences describing the tender."
+# summary_km: "..."
+
+scope:
+  - "Scope item 1."
+  - "Scope item 2."
+# Bilingual: use  - en: "..." / km: "..."  per item
+
+eligibility_requirements:
+  - "Eligibility 1."
+  - "Eligibility 2."
+
+required_documents:
+  - "Document 1"
+  - "Document 2"
+
+# goods:              # optional – table of items
+#   - description: "Item name"
+#     description_km: ""
+#     specification: "Spec text"
+#     unit: "unit"
+#     qty: 1
+
+commercial_terms:
+  bid_validity_days: 90
+  warranty: ""
+  payment_terms: "As per contract."
+  currency: "USD"
+
+# commercial_terms_km:
+#   payment_terms: "..."
+
+evaluation:
+  criteria:
+    - "Criterion 1"
+    - "Criterion 2"
+  # scoring:          # optional
+  #   - label: "Technical"
+  #     weight: "70%"
+  #   - label: "Financial"
+  #     weight: "30%"
+
+required_submissions:
+  - label: "Technical Response Form"
+    # label_km: "..."
+    type: "form"
+    url: "/assets/tenders/<slug>/form.docx"
+    required: true
+    note: "Complete and submit with proposal."
+    # note_km: "..."
+
+# resources:          # optional links
+#   - label: "Guideline"
+#     url: "https://..."
+#     note: ""
+
+attachments:
+  - label: "Tender document (PDF)"
+    # label_km: "..."
+    url: "/assets/tenders/<slug>/tender.pdf"
+
+# body_km: |          # optional Khmer body (markdown)
+#   អត្ថបទខ្មែរ...
+---
+
+Optional body text in English (Markdown). Shown below all sections. Add any additional terms, notes, or instructions here.

--- a/_tenders/capred-2026-0058.md
+++ b/_tenders/capred-2026-0058.md
@@ -1,6 +1,7 @@
 ---
 layout: tender
 title: "CAPRED: Domestic Bond Guarantee Capacity Enhancement"
+title_km: "CAPRED: ការពង្រឹងសមត្ថភាពធានាមូលបត្របំណុលក្នុងស្រុក"
 tender_id: "CAPRED-2026-0058"
 published: true
 date_posted: 2026-02-22
@@ -14,6 +15,9 @@ buyer:
   email: ["info@capred.org", "procurement@capred.org"]
   website: "https://www.capred.org"
 
+buyer_km:
+  name: "ភាពរួមភាគីកម្ពុជា-អូស្ត្រាលី ដើម្បីការអភិវឌ្ឍសេដ្ឋកិច្ចមានភាពធន់ (CAPRED)"
+
 location:
   province: "Phnom Penh"
   district: ""
@@ -26,22 +30,35 @@ deadline:
   timezone_label: "Phnom Penh (UTC+7)"
   note: "Proposals received after 5 pm will not be considered."
 
+deadline_km:
+  note: "ជាមតិដែលទទួលបន្ទាប់ពីម៉ោង ៥ ល្ងាចនឹងមិនត្រូវបានពិចារណា។"
+
 submission:
   methods: ["email"]
   rules:
-    - "Technical and Financial Response Forms must be submitted together."
-    - "Proposals must be clearly marked as for Component A, B or A and B."
-    - "Separate financial proposal required for each component (A and B) if bidding for both."
+    - en: "Technical and Financial Response Forms must be submitted together."
+      km: "ទម្រង់ឆ្លើយតបបច្ចេកទេស និងហិរញ្ញវត្ថុត្រូវដាក់ជាមតិជាមួយគ្នា។"
+    - en: "Proposals must be clearly marked as for Component A, B or A and B."
+      km: "ជាមតិត្រូវសម្គាល់ឱ្យច្បាស់ថាសម្រាប់ផ្នែក ក ខ ឬ ក និង ខ។"
+    - en: "Separate financial proposal required for each component (A and B) if bidding for both."
+      km: "ជាមតិហិរញ្ញវត្ថុដាច់ដោយឡែកត្រូវការសម្រាប់ផ្នែកនីមួយៗ (ក និង ខ) ប្រសិនបើដាក់ជាមតិទាំងពីរ។"
   email: "procurement@capred.org"
   physical_address: ""
   subject_line_format: "Domestic Bond Guarantee Capacity Enhancement"
   instructions: "Submit by 5 pm (Phnom Penh time), 1 March 2026. Email subject line must be 'Domestic Bond Guarantee Capacity Enhancement'. Enquiries: use subject 'Domestic Bond Guarantee Capacity Enhancement - Enquiry'."
 
+submission_km:
+  instructions: "ដាក់ជាមតិមុនម៉ោង ៥ ល្ងាច (ម៉ោងភ្នំពេញ) ថ្ងៃទី ១ មីនា ២០២៦។ ប្រធានបទអ៉ីមែលត្រូវជា 'ការពង្រឹងសមត្ថភាពធានាមូលបត្របំណុលក្នុងស្រុក'។ សំណួរ៖ ប្រើប្រធានបទ 'ការពង្រឹងសមត្ថភាពធានាមូលបត្របំណុលក្នុងស្រុក - សំណួរ'។"
+  subject_line_format: "ការពង្រឹងសមត្ថភាពធានាមូលបត្របំណុលក្នុងស្រុក"
+
 contacts:
   - name: "CAPRED Procurement"
+    name_km: "ការទិញរបស់ CAPRED"
     role: "Procurement"
+    role_km: "ការទិញ"
     email: ["procurement@capred.org"]
     location_label: "CAPRED Program"
+    location_label_km: "កម្មវិធី CAPRED"
 
 commercial_terms:
   bid_validity_days: null
@@ -49,51 +66,79 @@ commercial_terms:
   payment_terms: "As per contract; phase one (Component A) expected 3–4 months; option to extend to phase two."
   currency: "USD"
 
+commercial_terms_km:
+  payment_terms: "យោងតាមកិច្ចសន្យា។ ដំណាក់កាលមួយ (ផ្នែក ក) រំពឹង ៣–៤ ខែ។ ជម្រើសពង្រីកដល់ដំណាក់កាលពីរ។"
+
 evaluation:
   criteria:
-    - "Compliance with this Request for Proposal"
-    - "Understanding and ability to meet the eligibility criteria"
-    - "Positive contribution to GEDSI, climate resilience, and/or environmental protection"
-    - "Expertise of individuals and overall team nominated"
-    - "Past performance (referee checks) and relevant examples of previous work"
-    - "Proposed financial plan and value for money"
+    - en: "Compliance with this Request for Proposal"
+      km: "ការអនុវត្តតាមសំណើរបស់ការផ្តល់ជាមតិនេះ"
+    - en: "Understanding and ability to meet the eligibility criteria"
+      km: "ការយល់ដឹង និងសមត្ថភាពក្នុងការបំពេញលក្ខខណ្ឌគ្រប់គ្រាន់"
+    - en: "Positive contribution to GEDSI, climate resilience, and/or environmental protection"
+      km: "ការចូលរួមវិជ្ជមានចំពោះ GEDSI ភាពធន់នឹងអាកាសធាតុ និង/ឬការការពារបរិស្ថាន"
+    - en: "Expertise of individuals and overall team nominated"
+      km: "ជំនាញរបស់បុគ្គលិក និងក្រុមទាំងមូលដែលតែងតាំង"
+    - en: "Past performance (referee checks) and relevant examples of previous work"
+      km: "ការអនុវត្តកាលពីមុន (ការត្រួតពិនិត្យអ្នកយោង) និងឧទាហរណ៍ការងារពីមុនពាក់ព័ន្ធ"
+    - en: "Proposed financial plan and value for money"
+      km: "ផែនការហិរញ្ញវត្ថុដែលផ្តល់ជាមតិ និងតម្លៃរូបិយប័ណ្ណ"
   scoring: []
 
 required_submissions:
   - label: "Technical Response Form"
+    label_km: "ទម្រង់ឆ្លើយតបបច្ចេកទេស"
     type: "form"
     url: "/assets/tenders/capred-2026-0058/RFP26-058-TechnicalResponseForm_38706.docx"
     required: true
     note: "Complete and submit with proposal; indicate Component A, B or A and B."
+    note_km: "បំពេញ និងដាក់ជាមតិជាមួយជាមតិ។ សម្គាល់ផ្នែក ក ខ ឬ ក និង ខ។"
   - label: "Financial Response Form"
+    label_km: "ទម្រង់ឆ្លើយតបហិរញ្ញវត្ថុ"
     type: "form"
     url: "/assets/tenders/capred-2026-0058/RFP26-058-FinancialResponseForm_38706.docx"
     required: true
     note: "Separate form for Component A and Component B if bidding for both."
+    note_km: "ទម្រង់ដាច់ដោយឡែកសម្រាប់ផ្នែក ក និង ខ ប្រសិនបើដាក់ជាមតិទាំងពីរ។"
 
 summary: "Consultancy to support the Credit Guarantee Corporation of Cambodia (CGCC) in enhancing its domestic bond guarantee services. Two components: (A) review and enhance CGCC's existing bond guarantee framework and alignment with new regulations; (B) transaction advisory for infrastructure bond guarantees. Bidders may bid for A, B, or both. Phase one (Component A) 3–4 months; contract may extend to phase two."
+summary_km: "ការពិគ្រោះយោបល់ដើម្បីគាំទ្រក្រុមហ៊ុនធានាឥណ៌ាកម្ពុជា (CGCC) ក្នុងការពង្រឹងសេវាធានាមូលបត្របំណុលក្នុងស្រុក។ ពីរផ្នែក៖ (ក) ពិនិត្យ និងពង្រឹងរូបមន្តធានាមូលបត្រ និងការតម្រឹមច្បាប់ថ្មី។ (ខ) ការណែនាំយោបល់ធ្វើដំណើរការសម្រាប់ធានាមូលបត្រហេដ្ឋារចនាសម្ព័ន្ធ។ អ្នកដាក់ជាមតិអាចដាក់ជាមតិផ្នែក ក ខ ឬទាំងពីរ។ ដំណាក់កាលមួយ (ផ្នែក ក) ៣–៤ ខែ។ កិច្ចសន្យាអាចពង្រីកដល់ដំណាក់កាលពីរ។"
 
 scope:
-  - "Component A: Review CGCC's existing bond guarantee framework, guidelines and procedures (assessment, covenants, monitoring, risk management, capital adequacy, pricing, claim/recovery, eligibility, approval). Review Cambodian capital-market regulations (Private Placement, Infrastructure Bonds, Green/Social/Sustainable Bonds, SERC/MEF/CSX/NBC guidance). Gap analysis, stakeholder consultations, recommendations for improvement and agreed updates. Capacity building and templates/tools as agreed."
-  - "Component B: Transaction-oriented advisory for CGCC on specific infrastructure bonds—review project documents, assess project-finance risks, advise on due diligence and guarantee structuring (coverage, covenants, monitoring), ensure regulatory alignment, support negotiations with issuers and lead managers, and provide on-the-job capacity building."
+  - en: "Component A: Review CGCC's existing bond guarantee framework, guidelines and procedures (assessment, covenants, monitoring, risk management, capital adequacy, pricing, claim/recovery, eligibility, approval). Review Cambodian capital-market regulations (Private Placement, Infrastructure Bonds, Green/Social/Sustainable Bonds, SERC/MEF/CSX/NBC guidance). Gap analysis, stakeholder consultations, recommendations for improvement and agreed updates. Capacity building and templates/tools as agreed."
+    km: "ផ្នែក ក៖ ពិនិត្យរូបមន្តធានាមូលបត្រ គោលការណ៍ និងនីតិវិធីរបស់ CGCC (ការវាយតម្លៃ កិច្ចព្រមព្រៀង ការតាមដាន ការគ្រប់គ្រងហានិភ័យ ភាពគ្រប់គ្រាន់របស់មូលនិធិ ការកំណត់តម្លៃ ការទាមទារ/ការសង្គ្រោះ លក្ខខណ្ឌគ្រប់គ្រាន់ ការអនុម័ត)។ ពិនិត្យច្បាប់ទីផ្សារមូលបត្រកម្ពុជា (ការដាក់ភ្នាក់ងារឯកជន មូលបត្រហេដ្ឋារចនាសម្ព័ន្ធ មូលបត្របៃតង/សង្គម/ចម្ងាយរយៈ)។ ការវិភាគគម្លាត ការពិគ្រោះភាគីពាក់ព័ន្ធ ការណែនាំឱ្យប្រសើរ និងការធ្វើបច្ចុប្បន្នភាព។ ការកសាងសមត្ថភាព និងគំរូ/ឧបករណ៍យោងតាមការយល់ព្រម។"
+  - en: "Component B: Transaction-oriented advisory for CGCC on specific infrastructure bonds—review project documents, assess project-finance risks, advise on due diligence and guarantee structuring (coverage, covenants, monitoring), ensure regulatory alignment, support negotiations with issuers and lead managers, and provide on-the-job capacity building."
+    km: "ផ្នែក ខ៖ ការណែនាំយោបល់ផ្តោតលើធ្វើដំណើរការសម្រាប់ CGCC លើមូលបត្រហេដ្ឋារចនាសម្ព័ន្ធ—ពិនិត្យឯកសារគម្រោង វាយតម្លៃហានិភ័យហិរញ្ញវត្ថុគម្រោង ណែនាំពីការពិនិត្យគ្រប់គ្រាន់ និងរចនាសម្ព័ន្ធធានា (ការគ្រប កិច្ចព្រមព្រៀង ការតាមដាន) ធានាការតម្រឹមច្បាប់ គាំទ្រការចរចាជាមួយអ្នកចេញផ្សាយ និងអ្នកគ្រប់គ្រងដឹកនាំ និងផ្តល់ការកសាងសមត្ថភាពក្នុងការងារ។"
 
 eligibility_requirements:
-  - "Component A: Proven track record in financial sector development, capital market advisory, or project finance; experience designing or operationalizing credit guarantee mechanisms; experience with governments, regulators or DFIs in the region; similar assignments in Cambodia/ASEAN or comparable markets; strong understanding of bond market development and Cambodian securities regulations; expertise in credit risk, pricing, guarantee structuring; familiarity with PPP/infrastructure project finance; knowledge of regional guarantee institutions."
-  - "Component B: Proven experience in infrastructure finance, capital markets or credit guarantee operations in emerging/developing economies; experience with credit guarantee schemes in infrastructure or project finance; track record in transaction advisory for infrastructure bonds or credit enhancement; expertise in risk-based pricing, financial modelling, revenue/cost analysis; understanding of infrastructure design, construction and operational risk; ability to review ESIAs/ESMPs and address GEDSI, safeguards and climate; knowledge of domestic financial markets and local regulatory frameworks."
-  - "All: Integrity and high ethical standards; compliance with DFAT and Cowater policies (Child Protection, PSEAH, Fraud and Corruption Control, Value for Money); compliance with Cambodian law and environmental/safeguard policies. Teams with appropriate gender balance encouraged."
+  - en: "Component A: Proven track record in financial sector development, capital market advisory, or project finance; experience designing or operationalizing credit guarantee mechanisms; experience with governments, regulators or DFIs in the region; similar assignments in Cambodia/ASEAN or comparable markets; strong understanding of bond market development and Cambodian securities regulations; expertise in credit risk, pricing, guarantee structuring; familiarity with PPP/infrastructure project finance; knowledge of regional guarantee institutions."
+    km: "ផ្នែក ក៖ ប្រវត្តិការងារបញ្ជាក់ក្នុងការអភិវឌ្ឍវិស័យហិរញ្ញវត្ថុ ការណែនាំទីផ្សារមូលបត្រ ឬហិរញ្ញវត្ថុគម្រោង។ បទពិសោធន៍ក្នុងការរចនា ឬដំណើរការយន្តការធានាឥណ៌ា។ បទពិសោធន៍ជាមួយរដ្ឋាភិបាល អាជ្ញាធរ ឬ DFI ក្នុងតំបន់។ ការងារស្រដៀងគ្នាក្នុងកម្ពុជា/អាស៊ាន។ ការយល់ដឹងរឹងមាំពីការអភិវឌ្ឍទីផ្សារមូលបត្រ និងច្បាប់វិញ្ញាបនបត្រកម្ពុជា។ ជំនាញហានិភ័យឥណ៌ា កំណត់តម្លៃ រចនាធានា។ ល្បិចហិរញ្ញវត្ថុគម្រោង PPP/ហេដ្ឋារចនាសម្ព័ន្ធ។"
+  - en: "Component B: Proven experience in infrastructure finance, capital markets or credit guarantee operations in emerging/developing economies; experience with credit guarantee schemes in infrastructure or project finance; track record in transaction advisory for infrastructure bonds or credit enhancement; expertise in risk-based pricing, financial modelling, revenue/cost analysis; understanding of infrastructure design, construction and operational risk; ability to review ESIAs/ESMPs and address GEDSI, safeguards and climate; knowledge of domestic financial markets and local regulatory frameworks."
+    km: "ផ្នែក ខ៖ បទពិសោធន៍បញ្ជាក់ក្នុងហិរញ្ញវត្ថុហេដ្ឋារចនាសម្ព័ន្ធ ទីផ្សារមូលបត្រ ឬប្រតិបត្តិការធានាឥណ៌ាក្នុងសេដ្ឋកិច្ចកំពុងអភិវឌ្ឍ។ បទពិសោធន៍ជាមួយគ្រោងការណ៍ធានាឥណ៌ាក្នុងហេដ្ឋារចនាសម្ព័ន្ធ។ ប្រវត្តិការណែនាំយោបល់ធ្វើដំណើរការសម្រាប់មូលបត្រហេដ្ឋារចនាសម្ព័ន្ធ។ ជំនាញកំណត់តម្លៃផ្អែកហានិភ័យ គំរូហិរញ្ញវត្ថុ។ ការយល់ពីការរចនា សំណង និងហានិភ័យប្រតិបត្តិការ។ សមត្ថភាពពិនិត្យ ESIA/ESMP និងដោះស្រាយ GEDSI ការពារ និងអាកាសធាតុ។"
+  - en: "All: Integrity and high ethical standards; compliance with DFAT and Cowater policies (Child Protection, PSEAH, Fraud and Corruption Control, Value for Money); compliance with Cambodian law and environmental/safeguard policies. Teams with appropriate gender balance encouraged."
+    km: "ទាំងអស់៖ ភាពស្មោះត្រង់ និងស្តង់ដារក្រមវិជ្ជាខ្ពស់។ ការអនុវត្តតាមគោលការណ៍ DFAT និង Cowater (ការពារកុមារ PSEAH ការគ្រប់គ្រងអំពើពុករលួយ)។ ការអនុវត្តច្បាប់កម្ពុជា និងគោលការណ៍បរិស្ថាន/ការពារ។ ក្រុមដែលមានតុល្យភាពយេនឌ័រសមរម្យត្រូវបានលើកទឹកចិត្ត។"
 
 required_documents:
-  - "Technical Response Form (completed)"
-  - "Financial Response Form (separate for Component A and B if bidding for both)"
-  - "Proposal clearly marked for Component A, B or A and B"
+  - en: "Technical Response Form (completed)"
+    km: "ទម្រង់ឆ្លើយតបបច្ចេកទេស (បំពេញរួច)"
+  - en: "Financial Response Form (separate for Component A and B if bidding for both)"
+    km: "ទម្រង់ឆ្លើយតបហិរញ្ញវត្ថុ (ដាច់ដោយឡែកសម្រាប់ផ្នែក ក និង ខ ប្រសិនបើដាក់ជាមតិទាំងពីរ)"
+  - en: "Proposal clearly marked for Component A, B or A and B"
+    km: "ជាមតិសម្គាល់ឱ្យច្បាស់សម្រាប់ផ្នែក ក ខ ឬ ក និង ខ"
 
 attachments:
   - label: "RFP – Domestic Bond Guarantee Capacity Enhancement (FINAL)"
+    label_km: "RFP – ការពង្រឹងសមត្ថភាពធានាមូលបត្របំណុលក្នុងស្រុក (ចុងក្រោយ)"
     url: "/assets/tenders/capred-2026-0058/RFP26-0058-DomesticBondGuaranteeCapacityEnhancement-FINAL_38706.pdf"
   - label: "Technical Response Form"
+    label_km: "ទម្រង់ឆ្លើយតបបច្ចេកទេស"
     url: "/assets/tenders/capred-2026-0058/RFP26-058-TechnicalResponseForm_38706.docx"
   - label: "Financial Response Form"
+    label_km: "ទម្រង់ឆ្លើយតបហិរញ្ញវត្ថុ"
     url: "/assets/tenders/capred-2026-0058/RFP26-058-FinancialResponseForm_38706.docx"
+
+body_km: |
+  CAPRED អាចផ្តល់ជាមតិផ្នែក ក និង ខ ដល់អ្នកផ្គត់ផ្គង់ខុសគ្នា។ បេក្ខជនដែលជាប់ shortlist នឹងត្រូវបានអញ្ជើញមកសម្ភាសន៍។ ការពិនិត្យគ្រប់គ្រាន់នឹងត្រូវធ្វើឡើងលើអង្គការ និងបុគ្គលមុនផ្តល់ជាមតិ។ CAPRED រក្សាសិទ្ធិក្នុងការផ្លាស់ប្តូរលក្ខខណ្ឌកិច្ចសន្យា និងអនុវត្តរយៈពេលជម្រើសតាមចិត្តរបស់ខ្លួន។
 ---
 
 CAPRED may award Component A and Component B to different suppliers. Shortlisted candidates will be invited for interview. Due diligence will be conducted on organisations and individuals prior to award. CAPRED reserves the right to vary contract terms and to exercise option periods at its sole discretion.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -211,6 +211,52 @@ body {
   padding-top: 0.5rem;
 }
 
+/* Language switcher: show only the active language */
+.tender-detail[data-tender-lang="en"] .tender-lang-km {
+  display: none;
+}
+.tender-detail[data-tender-lang="km"] .tender-lang-en {
+  display: none;
+}
+
+.tender-lang-switcher-wrap {
+  margin-bottom: 1rem;
+}
+.tender-lang-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.tender-lang-sep {
+  color: var(--color-border);
+  font-weight: 300;
+}
+.tender-lang-btn {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  font-family: inherit;
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.tender-lang-btn:hover {
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.tender-lang-btn.active {
+  background: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+.tender-lang-btn.active:hover {
+  background: var(--color-primary-hover);
+  color: #fff;
+  border-color: var(--color-primary-hover);
+}
+
 .tender-header {
   margin-bottom: 2rem;
   padding-bottom: 1.5rem;

--- a/assets/js/tender-lang.js
+++ b/assets/js/tender-lang.js
@@ -1,0 +1,38 @@
+(function () {
+  var STORAGE_KEY = "tender-lang";
+  var article = document.getElementById("tender-detail");
+  if (!article) return;
+
+  function getStored() {
+    try {
+      var stored = localStorage.getItem(STORAGE_KEY);
+      if (stored === "en" || stored === "km") return stored;
+    } catch (e) {}
+    return "en";
+  }
+
+  function setLang(lang) {
+    if (lang !== "en" && lang !== "km") return;
+    article.setAttribute("data-tender-lang", lang);
+    document.documentElement.setAttribute("lang", lang === "km" ? "km" : "en");
+    try {
+      localStorage.setItem(STORAGE_KEY, lang);
+    } catch (e) {}
+    var btns = article.querySelectorAll(".tender-lang-btn");
+    btns.forEach(function (btn) {
+      var isActive = btn.getAttribute("data-lang") === lang;
+      btn.classList.toggle("active", isActive);
+      btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+  }
+
+  var initial = getStored();
+  setLang(initial);
+
+  article.addEventListener("click", function (e) {
+    var btn = e.target.closest(".tender-lang-btn");
+    if (!btn) return;
+    var lang = btn.getAttribute("data-lang");
+    if (lang) setLang(lang);
+  });
+})();


### PR DESCRIPTION
- Added a language switcher to the tender layout, allowing users to toggle between English and Khmer.
- Updated tender templates and existing tender files to support bilingual content, including optional Khmer fields.
- Introduced JavaScript functionality to store and manage the selected language preference.
- Updated CSS styles for the language switcher to improve user experience.
- Excluded the _templates directory from processing in the configuration file.