### PR TITLE
Add procurement intake page and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ scope:
 - The site adds `?tender_id=<tender_id>` (or `&tender_id=...` if the base URL already contains `?`).
 - If `vendor_form.base_url` is missing or empty, the CTA is hidden and a short note is shown: "Vendor response form not available."
 
+## Procurement Intake (Phase 0)
+
+The site has a public intake page at **/submit/** where procurement officers can upload tender documents. There is no authentication; access is controlled by sharing the `/submit` URL only with trusted procurement contacts.
+
+### How it works
+
+1. **Create a form** in Tally.so (preferred) or Google Forms with file upload enabled.
+2. **Configure the site:** In `submit.md` front matter, set `form_url` to your form’s embed or share URL (e.g. Tally form URL or Google Form “embed” link). Set `form_provider` to `tally` or `google` for your own reference.
+3. **Form fields to include:** Organization name (required), tender title, tender reference number, deadline (date/time/timezone), submission method (email/physical/both), contact person and phone/email, notes, and **file upload (multiple, required)**. The submit page lists these as a checklist for submitters.
+4. **Storage and notifications:** Tally stores uploads in your Tally account and can email you on each submission; Google Forms stores files in Google Drive and can notify you by email. Configure notifications in the form provider.
+5. **After a submission:** You receive an email and a new row in the form’s spreadsheet (Tally or Google Sheets). Create a new tender file: `cp _templates/tender.md _tenders/<id>.md`, fill it from the submission (add attachment links from Tally/Drive), set `published: true` when ready, then commit and push.
+
+### Security
+
+- No login is required on the site. Keep the intake URL private (share only with procurement officers).
+- Optionally add a simple anti-spam measure in the form (e.g. Tally’s hidden field / honeypot if supported). No backend or plugins are used.
+
 ## Deploy (GitHub Pages)
 
 1. In the repo: **Settings → Pages**.
@@ -148,6 +165,7 @@ The body of the file can contain extra Markdown (longer scope, notes, figures, e
 ## URLs
 
 - Homepage: `/`
+- Submit tender documents: `/submit/`
 - Tender detail: `/tenders/<slug>/` (slug = filename without `.md`)
 - 404: `/404.html`
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,6 +3,7 @@
     <a class="site-title" href="{{ '/' | relative_url }}">{{ site.title }}</a>
     <nav class="site-nav">
       <a href="{{ '/' | relative_url }}">Tenders</a>
+      <a href="{{ '/submit/' | relative_url }}">Submit</a>
     </nav>
   </div>
 </header>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -568,6 +568,89 @@ body {
   color: var(--color-text-muted);
 }
 
+/* Submit page (procurement intake) */
+.submit-page .page-title {
+  margin-bottom: 0.5rem;
+}
+
+.submit-page .page-intro {
+  margin-bottom: var(--spacing);
+}
+
+.submit-checklist-title {
+  margin: 1.5rem 0 0.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.submit-checklist-intro {
+  margin: 0 0 0.75rem;
+  font-size: 0.9375rem;
+  color: var(--color-text-muted);
+}
+
+.submit-checklist {
+  margin: 0 0 1.5rem;
+  padding-left: 1.25rem;
+}
+
+.submit-checklist li {
+  margin: 0.35rem 0;
+}
+
+.callout {
+  margin: 0 0 var(--spacing);
+  padding: 1rem 1.25rem;
+  background: #f0f4ff;
+  border: 1px solid #c5daf5;
+  border-radius: 6px;
+  font-size: 0.9375rem;
+}
+
+.callout p:first-child {
+  margin-top: 0;
+}
+
+.callout ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.callout li {
+  margin: 0.25rem 0;
+}
+
+.callout-warning {
+  background: #fff8e6;
+  border-color: #e6c84a;
+}
+
+.callout code {
+  font-size: 0.875em;
+  padding: 0.1rem 0.35rem;
+  background: rgba(0, 0, 0, 0.06);
+  border-radius: 3px;
+}
+
+.form-embed {
+  width: 100%;
+  min-height: 900px;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: #fafafa;
+}
+
+.form-embed iframe {
+  display: block;
+  width: 100%;
+  min-height: 900px;
+  height: 100%;
+  border: 0;
+  overflow-x: hidden;
+}
+
 /* Mobile */
 @media (max-width: 640px) {
   .main {
@@ -580,5 +663,10 @@ body {
 
   .search-input {
     max-width: none;
+  }
+
+  .form-embed,
+  .form-embed iframe {
+    min-height: 800px;
   }
 }

--- a/submit.md
+++ b/submit.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Submit Tender Documents
+form_provider: tally
+form_url: "https://tally.so/embed/xXpE2k?alignLeft=1&hideTitle=1&transparentBackground=1&dynamicHeight=1"
+---
+
+<div class="submit-page">
+  <div class="wrap">
+    <h1 class="page-title">{{ page.title }}</h1>
+    <p class="page-intro">Use this page to upload tender documents for publishing. This is for procurement officers who have tender packages (ITB, RFP, BOQ, etc.) and want them added to the Keoyet Tenders site.</p>
+
+    {% assign form_url_effective = page.form_url | strip %}
+    {% if form_url_effective == "" or form_url_effective == "<INSERT_FORM_URL_HERE>" %}
+    <div class="callout callout-warning">
+      <p><strong>Form not configured.</strong> Set <code>form_url</code> in the front matter of <code>submit.md</code> to your Tally or Google Form embed URL.</p>
+    </div>
+    {% else %}
+    <div class="form-embed">
+      {% if page.form_provider == "tally" %}
+      <iframe data-tally-src="{{ page.form_url }}" loading="lazy" width="100%" height="667" frameborder="0" marginheight="0" marginwidth="0" title="Submit Tender Documents (Keoyet)"></iframe>
+      <script>
+        (function(){var d=document,w="https://tally.so/widgets/embed.js",v=function(){if(typeof Tally!=="undefined")Tally.loadEmbeds();else d.querySelectorAll("iframe[data-tally-src]:not([src])").forEach(function(e){e.src=e.dataset.tallySrc});};if(typeof Tally!=="undefined")v();else if(!d.querySelector('script[src="'+w+'"]')){var s=d.createElement("script");s.src=w;s.onload=v;s.onerror=v;d.body.appendChild(s)}})();
+      </script>
+      {% else %}
+      <iframe title="Submit tender documents form" src="{{ page.form_url }}" frameborder="0" allowfullscreen allow="clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+      {% endif %}
+    </div>
+    {% endif %}
+  </div>
+</div>


### PR DESCRIPTION
- Introduced a new public intake page at `/submit/` for procurement officers to upload tender documents without authentication.
- Updated `README.md` to include details on the procurement intake process, form configuration, and security measures.
- Added CSS styles for the new submit page and its elements to enhance user experience.
- Updated the site header to include a link to the new submit page.